### PR TITLE
Fix absolute URI to gradient background

### DIFF
--- a/sass/_hero.scss
+++ b/sass/_hero.scss
@@ -90,7 +90,7 @@
           }
 
           .bgImage {
-            background-image: url(/public/images/boxGradient.png);
+            background-image: url(../public/images/boxGradient.png);
             background-position: center;
             background-repeat: no-repeat;
             background-size: contain;
@@ -124,7 +124,7 @@
             width: 120px;
             height: 120px;
             z-index: 1;
-            background-image: url(/public/images/boxGradientBehind.png);
+            background-image: url(../public/images/boxGradientBehind.png);
             background-position: center;
             background-repeat: no-repeat;
             background-size: contain;


### PR DESCRIPTION
This ends up being compiled as absolute path in the generated HTML and results in missing background set via CSS. Use relative path instead so that the build changes it appropriately.