### PR TITLE
UI and accessibility changes in the header

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -44,7 +44,29 @@ function Header(props) {
   function toggleMenu() {
     // var viewportWidth =
     //   window.innerWidth || document.documentElement.clientWidth;
+
     const burgerWrapper = document.querySelector(".mainMenu.device");
+
+
+    // trap focus in the burger menu for accessibility purposes
+    const firstFocusableEl = burgerWrapper.querySelector('button:not([disabled])')
+    const lastFocusableEl = burgerWrapper.querySelector('ul li:last-child a')
+    
+    burgerWrapper.addEventListener("keydown", e => {
+      if (e.key === 'Tab') {
+        if (e.shiftKey)  {
+          if (document.activeElement === firstFocusableEl) {
+            lastFocusableEl.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastFocusableEl) {
+            firstFocusableEl.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    });
 
     // if (viewportWidth <= 991) {
     if (burgerWrapper.classList.contains("menuActive")) {
@@ -137,73 +159,13 @@ function Header(props) {
 
             <button className="noStyle navbar-toggle" onClick={toggleMenu}>
               <span className="visually-hidden">Toggle Navigation</span>
-              <span className="icon-bar">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  x="0"
-                  y="0"
-                  viewBox="0 0 16 2.3"
-                >
-                  <path d="M0 1.1C0 .8.1.5.3.3s.5-.3.8-.3h13.7c.3 0 .6.1.8.3.3.2.4.5.4.8 0 .3-.1.6-.3.8-.2.2-.5.3-.8.3H1.1c-.3.1-.6 0-.8-.2-.2-.3-.3-.6-.3-.9z"></path>
-                </svg>
-              </span>
-              <span className="icon-bar">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  x="0"
-                  y="0"
-                  viewBox="0 0 16 2.3"
-                >
-                  <path d="M0 1.1C0 .8.1.5.3.3s.5-.3.8-.3h13.7c.3 0 .6.1.8.3.3.2.4.5.4.8 0 .3-.1.6-.3.8-.2.2-.5.3-.8.3H1.1c-.3.1-.6 0-.8-.2-.2-.3-.3-.6-.3-.9z"></path>
-                </svg>
-              </span>
-              <span className="icon-bar">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  x="0"
-                  y="0"
-                  viewBox="0 0 16 2.3"
-                >
-                  <path d="M0 1.1C0 .8.1.5.3.3s.5-.3.8-.3h13.7c.3 0 .6.1.8.3.3.2.4.5.4.8 0 .3-.1.6-.3.8-.2.2-.5.3-.8.3H1.1c-.3.1-.6 0-.8-.2-.2-.3-.3-.6-.3-.9z"></path>
-                </svg>
-              </span>
+              <div className="hamburger"></div>
             </button>
           </div>
         </div>
       </header>
       <nav className="mainMenu device">
-        <button className="noStyle navbar-toggle menuActive" onClick={toggleMenu}>
-          <span className="visually-hidden">Toggle Navigation</span>
-          <span className="icon-bar">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              x="0"
-              y="0"
-              viewBox="0 0 16 2.3"
-            >
-              <path d="M0 1.1C0 .8.1.5.3.3s.5-.3.8-.3h13.7c.3 0 .6.1.8.3.3.2.4.5.4.8 0 .3-.1.6-.3.8-.2.2-.5.3-.8.3H1.1c-.3.1-.6 0-.8-.2-.2-.3-.3-.6-.3-.9z"></path>
-            </svg>
-          </span>
-          <span className="icon-bar">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              x="0"
-              y="0"
-              viewBox="0 0 16 2.3"
-            >
-              <path d="M0 1.1C0 .8.1.5.3.3s.5-.3.8-.3h13.7c.3 0 .6.1.8.3.3.2.4.5.4.8 0 .3-.1.6-.3.8-.2.2-.5.3-.8.3H1.1c-.3.1-.6 0-.8-.2-.2-.3-.3-.6-.3-.9z"></path>
-            </svg>
-          </span>
-          <span className="icon-bar">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              x="0"
-              y="0"
-              viewBox="0 0 16 2.3"
-            >
-              <path d="M0 1.1C0 .8.1.5.3.3s.5-.3.8-.3h13.7c.3 0 .6.1.8.3.3.2.4.5.4.8 0 .3-.1.6-.3.8-.2.2-.5.3-.8.3H1.1c-.3.1-.6 0-.8-.2-.2-.3-.3-.6-.3-.9z"></path>
-            </svg>
-          </span>
+        <button tabIndex="0" className="noStyle navbar-toggle menuActive" onClick={toggleMenu}>
         </button>
         <ul>
           <li>

--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -310,7 +310,6 @@ button.navbar-toggle {
   .hamburger:after {
     transform: translate(-50%, -240%);
     background: currentColor;
-
   }
 
   @include media-breakpoint-up(lg) {

--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -277,6 +277,7 @@
 
 button.navbar-toggle {
   height: 100%;
+  color: $black;
   transition: color 0.2s ease;
 
   &:hover > * {

--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -4,15 +4,15 @@
   left: 0;
   width: 100%;
   z-index: 998;
-  padding-top: 20px;
-  padding-bottom: 20px;
+  height: 4rem;
+  display: flex;
   background-color: transparent;
-  //border: 1px solid transparent;
+  // border: 1px solid transparent;
   transition: padding-top 0.4s ease, background-color 0.4s ease;
 
   @include media-breakpoint-up(lg) {
-    padding-top: 25px;
-    padding-bottom: 25px;
+    height: 6rem;
+    padding-block: 1rem;
   }
 
   &[data-menu-active="true"] {
@@ -20,15 +20,7 @@
       background-color: transparent;
       transition: none;
     }
-    @include media-breakpoint-down(lg) {
-      //padding-top: 0;
-    }
 
-    .navbar-toggle {
-      @include media-breakpoint-down(lg) {
-       // padding-top: 25px;
-      }
-    }
   }
 
   &.scrolled{
@@ -36,21 +28,28 @@
   }
 
   .container {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
   }
 
   .leftWrapper {
+    height: 100%;
     display: flex;
     justify-content: flex-start;
     align-items: center;
+
+    a {
+      cursor: pointer;
+      text-decoration: none;
+      color: $black;
+    }
 
     h1 {
       font-weight: 600;
       margin: 0;
       font-size: 18px;
+      text-wrap: nowrap;
+      line-height: 0;
 
       @include media-breakpoint-up(lg) {
         font-size: 25px;
@@ -59,23 +58,10 @@
   }
 
   .centerWrapper {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
     align-items: center;
-    justify-content: space-between;
-
-    @media (min-width: 400px){
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
-    }
-
-    @include media-breakpoint-up(lg) {
-      position: static;
-      margin-left: 168px;
-      left: auto;
-      transform: none;
-    }
-
+    gap: 2px;
 
     .logo {
       width: 33px;
@@ -109,6 +95,7 @@
   }
 
   .rightWrapper {
+    height: 100%;
     display: flex;
     justify-content: flex-end;
     align-items: center;
@@ -131,16 +118,14 @@
 
   ul {
     list-style: none;
-    margin: 0 -22px;
-    padding: 0;
+    margin: 0;
 
     li {
       margin: 0;
-      padding: 0 0 22px 0;
+      padding-right: 1.5rem;
       display: block;
 
       @include media-breakpoint-up(lg) {
-        padding: 0 22px;
         display: inline-block;
       }
 
@@ -150,7 +135,7 @@
         font-weight: 400;
         text-decoration: none;
         color: $black;
-        transition: color 0.4s ease;
+        transition: color 0.2s ease;
         position: relative;
 
         &::after {
@@ -180,6 +165,10 @@
         }
       }
     }
+
+    li:last-child {
+      padding-right: 0;
+    }
   }
 }
 
@@ -196,115 +185,134 @@
   background: $white;
   transition: right 0.5s ease;
   z-index: 998;
+  box-shadow: 1px 2px 3px hsl(0deg 0% 0% / 0.5);
 
   &.menuActive {
     right: 0;
+    display: grid;
+    grid-template-rows: 4rem auto;
+    
+    > *:first-child {
+      right: 0.7rem;
+    }
+
+    li a::after {
+      display: none;
+    }
+
+    li:hover,
+    li:focus-within {
+      cursor: pointer;
+    }
+
+    li:focus-within a {
+      color: $blue;
+      outline: none;
+    }
+ 
+    button {
+      position: relative;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 4px;
+      cursor: pointer;
+      align-self: center;
+      justify-self: end;
+      transform: rotate(45deg);
+      transition: color 0.2s ease;
+
+      &:hover, &:active, &:focus {
+        color: $blue;
+        transition: color 0.2s ease;
+      }
+
+      &:before, &:after {
+        position: absolute;
+        width: 1.8rem;
+        height: 0.2rem;
+        transition: inherit;
+        content: '';   
+        border-radius: inherit; 
+      }
+ 
+      &:before {
+        transform-origin: 100% 50%;
+        background: currentcolor;
+        transform: translate(-50%, -50%);
+      }
+
+      &:after {
+        background: currentcolor;
+        transform: translateX(-50%) translateY(-50%) rotate(90deg);        
+      }
+    }
   }
 
   @include media-breakpoint-up(lg) {
     display: none;
   }
 
-  .navbar-toggle{
-    float: right;
-    padding-top: 24px;
-    padding-right: 24px;
-    margin-right: auto;
-  }
-
   ul {
     width: 100%;
-    margin-left: 70px;
-    margin-top: 80px;
+    padding: 0;
 
-    li{
-      padding: 0;
+    li {
+      padding-left: 1rem;
       border-bottom: 1px solid $dkGrey;
+      text-align: left;
 
-      a{
+      a {
         display: block;
         padding: 25px 0;
         font-size: 16px;
         font-weight: 500;
       }
     }
+
+    li:hover, li:focus-within {
+      cursor: pointer;
+    }
   }
 }
 
-.navbar-toggle {
-  position: relative;
-  margin-right: 24px;
-  margin-left: 4px;
-  padding: 2px 2px 4px 0px;
-  transform: translateY(0.9px);
-  z-index: 9997;
+button.navbar-toggle {
+  height: 100%;
+  transition: color 0.2s ease;
 
-  @include media-breakpoint-up(sm) {
-    margin-left: 24px;
+  &:hover > * {
+    color: $blue;
+    transition: color 0.2s ease;
+  }
+
+  .hamburger {
+    width: 1.8rem;
+    height: 0.2rem;
+    border-radius: 4px;
+    background: currentColor;
+    position: relative;
+    
+    &:before, &:after {
+      content: '';
+      position: absolute;
+      width: inherit;
+      height: inherit;
+      border-radius: inherit;
+      height: 99%; // small hack to fix Firefox bug
+    }
+  }
+  
+  .hamburger:before {
+    background: currentColor;
+    transform: translate(-50%, 240%);
+  }
+
+  .hamburger:after {
+    transform: translate(-50%, -240%);
+    background: currentColor;
+
   }
 
   @include media-breakpoint-up(lg) {
     display: none;
-  }
-
-  .icon-bar {
-    display: block;
-    width: 16px;
-    height: 3px;
-    margin: 0 auto;
-    position: relative;
-    transition: all 250ms ease-in-out;
-    cursor: pointer;
-
-    svg {
-      width: 28px;
-      height: auto;
-      display: block;
-      opacity: 1;
-      margin: 0;
-      fill: $black;
-      transition: fill 0.4s ease;
-    }
-  }
-  .icon-bar + .icon-bar {
-    margin-top: 3px;
-  }
-  .icon-bar:nth-of-type(2) {
-    z-index: 2;
-  }
-  .icon-bar:nth-of-type(3) {
-    top: 1px;
-  }
-  .icon-bar:nth-of-type(4) {
-    top: 2px;
-  }
-  &.menuActive {
-    // margin-right: 6px;
-
-    // &.marginFix {
-    //   margin-right: 13px;
-    // }
-
-    .icon-bar:nth-of-type(2) {
-      top: 0px;
-      transform: rotate(45deg);
-    }
-    .icon-bar:nth-of-type(3) {
-      svg {
-        opacity: 0;
-      }
-    }
-    .icon-bar:nth-of-type(4) {
-      top: -4px;
-      transform: rotate(-45deg);
-    }
-  }
-
-  &:hover {
-    .icon-bar {
-      svg {
-        fill: $blue;
-      }
-    }
   }
 }


### PR DESCRIPTION
This PR includes several changes to improve the UI and accessibility of the header and dropdown menu. Tested on Chrome, Safari and Firefox.


### Change #1:  Header structure

- Implementing grid instead of a flexbox makes sure that the logos are always centred, even if you add more items in the navbar. That also that prevents weird jumps when you resize the screen (video below), and fixes Safari bug where logos overlap.
- Suggestion - If you make the logo navigate to the Homepage, you can remove the Home link in the navbar - common UX practice.

#### Before

![Screenshot 2024-03-27 at 11 45 24](https://github.com/ipni/cid.contact/assets/50910606/8723b218-6e26-45dc-89d8-0406c3d7cd50)

Resizing the screen and alignment breaks:

https://github.com/ipni/cid.contact/assets/50910606/4d5e269f-47d2-49fc-852a-d00f628bec39

Scenario of adding more items in the nav, alignment breaks:
![Screenshot 2024-03-27 at 11 46 05](https://github.com/ipni/cid.contact/assets/50910606/058c59fe-cd5f-471e-89ab-560fe37e87d4) 

Safari bug:
![Screenshot 2024-03-28 at 07 57 33](https://github.com/ipni/cid.contact/assets/50910606/0c9d9b41-c7bb-4c81-9b9c-f37fbc519a06)

#### After

Grid layout:
![Screenshot 2024-03-27 at 11 43 55](https://github.com/ipni/cid.contact/assets/50910606/2a2acf55-fbd4-44da-8008-201381aaffa0)

Alignment doesn't break when adding more items:
![Screenshot 2024-03-27 at 11 44 31](https://github.com/ipni/cid.contact/assets/50910606/fde2c47a-39ad-46c3-9d46-bcc1745dbed2)

Smoother transitions and no jumps when resizing, and logos stay centered:

https://github.com/ipni/cid.contact/assets/50910606/1240a92d-82c0-440d-9ea1-2fa4969d46c8


### Change #2: Hamburger component

I have replaced `<span>` SVG elements in the dropdown burger button with pseudo elements `::before` and `::after`. Why? Less HTML code and now the icon can be animated if you decide to in the future. It also reduces the complexity of changing the style - if you wanted to be different length, color and similar. It could also be extracted as it's own component and reused somewhere else in the website.

### Change #3: Dropdown UI
- light dropdown shadow to make dropdown stand out when on a light background
- fixed the hover effect on dropdown menu items

#### Before
![Screenshot 2024-03-28 at 07 55 56](https://github.com/ipni/cid.contact/assets/50910606/f3eaa401-958e-4e8c-a9aa-88d5a90f36ab)

#### After
![Screenshot 2024-03-28 at 07 55 39](https://github.com/ipni/cid.contact/assets/50910606/8b4549b3-b534-4735-887c-ab7aafe185f9)

### Change #4: Dropdown accessibility
- dropdown component now traps the focus within, which allows users that use TAB to navigate effectively. 

#### Before
https://github.com/ipni/cid.contact/assets/50910606/0864105b-a17f-4207-8839-6ff108e7019c

#### After

https://github.com/ipni/cid.contact/assets/50910606/81abc4e1-e610-466c-8480-3cf925cf9733

