### PR TITLE
Add Service Degradation Banner to Homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -836,6 +836,16 @@ export default function Home(props) {
                 <strong>learn more.</strong>
               </a>
             </p>
+            <div className="banner">
+              <h4>Service degradation</h4>
+              <p>
+                Service is degraded as a large compaction debt from continued high reads has led to the database being stuck. We are in the process of restoring service via our alternate instances.{" "}
+                <br />
+                <span className="date">April 21, 2025</span>
+                <br />
+                <a href="https://status.cid.contact/" target="_blank" rel="noopener noreferrer">See status page for updates</a>
+              </p>
+            </div>
             <div
               className={
                 accordionState && !searchError ? "results active" : "results"

--- a/sass/_banner.scss
+++ b/sass/_banner.scss
@@ -1,0 +1,39 @@
+.banner {
+  background-color: #fff3cd;
+  border: 1px solid #ffeeba;
+  border-radius: 4px;
+  padding: 15px;
+  margin-bottom: 20px;
+  color: #856404;
+  max-width: 550px;
+  margin: 0 auto;
+
+  p {
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  h4 {
+    color: #5d4601;
+    font-weight: 600;
+    margin-bottom: 8px;
+    font-size: 1.1rem;
+  }
+
+  .date {
+    font-size: 0.9rem;
+    font-style: italic;
+    margin: 8px 0;
+    display: inline-block;
+  }
+
+  a {
+    color: #5d4601;
+    text-decoration: underline;
+    font-weight: 500;
+
+    &:hover {
+      color: #856404;
+    }
+  }
+}

--- a/sass/_hero.scss
+++ b/sass/_hero.scss
@@ -27,6 +27,7 @@
   > p {
     font-size: 0.8rem;
     font-weight: 400;
+    margin-bottom: 2rem;
 
     a {
       color: $dkrBlue;

--- a/sass/global.scss
+++ b/sass/global.scss
@@ -11,6 +11,7 @@
 @import '_header';
 @import '_footer';
 @import '_backgrounds';
+@import '_banner';
 
 // Sections
 @import '_hero';


### PR DESCRIPTION
## Description 

This PR adds a service status banner to the homepage to inform users about the current [service degradation due to database issues](https://status.cid.contact/). 

## Screenshot
<img width="952" alt="Screenshot 2025-05-01 at 15 28 25" src="https://github.com/user-attachments/assets/fe4b9fc0-2149-4aa0-a967-dcf4e77b0808" />
<img width="1109" alt="Screenshot 2025-05-01 at 15 28 44" src="https://github.com/user-attachments/assets/90d1374d-413c-467c-9692-1a0d83f12a25" />
